### PR TITLE
Add cross-platform setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,19 @@
 .roo/
 .roomodes
 
+# Node modules and build artifacts
+node_modules/
+dist/
+coverage/
+
+# IDE settings
+.vscode/
+.idea/
+
+# Misc data directories
+memory/
+pseudo/
+
 # Logs and temporary files
 logs/
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+# Detect operating system
+OS_NAME="$(uname -s)"
+
+# Helper to log messages
+log() {
+    echo "[setup] $1"
+}
+
 # Determine package manager
 if command -v apt-get > /dev/null; then
     PKG_MANAGER="apt-get"
@@ -23,37 +31,60 @@ elif command -v brew > /dev/null; then
     PKG_MANAGER="brew"
     INSTALL_CMD="brew install"
     UPDATE_CMD="brew update"
+elif command -v choco > /dev/null; then
+    PKG_MANAGER="choco"
+    INSTALL_CMD="choco install -y"
+    UPDATE_CMD="choco upgrade -y"
 else
     echo "Unsupported OS or package manager not found."
     exit 1
 fi
 
 # Update repositories
+log "Updating package lists using $PKG_MANAGER"
 $UPDATE_CMD
 
 # Example packages required for this project
 PACKAGES=(python3 python3-pip git)
 
 for pkg in "${PACKAGES[@]}"; do
-    $INSTALL_CMD "$pkg"
+    if ! command -v "${pkg%% *}" >/dev/null; then
+        log "Installing $pkg"
+        $INSTALL_CMD "$pkg"
+    else
+        log "$pkg already installed"
+    fi
 done
 
 # Setup Python virtual environment
-python3 -m venv .venv
+if [ ! -d .venv ]; then
+    log "Creating Python virtual environment"
+    python3 -m venv .venv
+fi
 source .venv/bin/activate
 pip install --upgrade pip
 
 # Install Python dependencies if requirements file exists
 if [ -f requirements.txt ]; then
+    log "Installing Python dependencies"
     pip install -r requirements.txt
+fi
+
+# Create environment file if template exists
+if [ -f .env.template ] && [ ! -f .env ]; then
+    cp .env.template .env
+    log "Created .env from template"
 fi
 
 # Node.js dependencies
 if [ -f package.json ] && command -v npm >/dev/null; then
+    log "Installing Node dependencies"
     npm install
+elif [ -f package.json ]; then
+    log "package.json found but npm is missing. Please install Node.js"
 fi
 
 cat <<MSG
-Setup complete using $PKG_MANAGER.
+Setup complete using $PKG_MANAGER on $OS_NAME.
 Activate the Python environment with 'source .venv/bin/activate'.
 MSG


### PR DESCRIPTION
## Summary
- provide a new `setup.sh` that automatically detects the available package manager
- install core packages and set up a Python virtual environment
- ignore common local files via `.gitignore`

## Testing
- `bash -n setup.sh`
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857645c9c4c83279872241dc2470d50